### PR TITLE
Define network parameters using HCL

### DIFF
--- a/examples/one_instance/one_instance.tf
+++ b/examples/one_instance/one_instance.tf
@@ -23,9 +23,18 @@ resource "shakenfist_instance" "sftest" {
         model = "cirrus"
         memory = 16384
     }
-    networks = [
-        "uuid=${shakenfist_network.sf-net-1.id}",
-        ]
+    network {
+        network_uuid = shakenfist_network.sf-net-1.id
+    }
+    network {
+        network_uuid = shakenfist_network.sf-net-1.id
+        ipv4 = "10.0.1.17"
+        model = "e1000"
+    }
+    network {
+        network_uuid = shakenfist_network.sf-net-1.id
+        mac = "12:34:56:78:9a:Bc"
+    }
     metadata = {
         person = "old man"
         action = "shakes fist"
@@ -43,5 +52,5 @@ resource "shakenfist_network" "sf-net-1" {
 }
 
 resource "shakenfist_float" "sf-float-1" {
-    interface = shakenfist_instance.sftest.interfaces[0]
+    interface = shakenfist_instance.sftest.network[0].interface_uuid
 }

--- a/examples/student_lab/student_lab.tf
+++ b/examples/student_lab/student_lab.tf
@@ -54,10 +54,12 @@ resource "shakenfist_instance" "jump" {
         model = "cirrus"
         memory = 16384
     }
-    networks = [
-        "uuid=${shakenfist_network.external.id}",
-        "uuid=${shakenfist_network.internal.id}",
-        ]
+    network {
+        network_uuid = shakenfist_network.external.id
+    }
+    network {
+        network_uuid = shakenfist_network.internal.id
+    }
     metadata = {
         person = "old man"
         action = "shakes fist"
@@ -65,7 +67,7 @@ resource "shakenfist_instance" "jump" {
 }
 
 resource "shakenfist_float" "external" {
-    interface = shakenfist_instance.jump.interfaces[0]
+    interface = shakenfist_instance.jump.network[0].interface_uuid
 }
 
 resource "shakenfist_network" "external" {
@@ -93,9 +95,9 @@ resource "shakenfist_instance" "target" {
         model = "cirrus"
         memory = 16384
     }
-    networks = [
-        "uuid=${shakenfist_network.internal.id}",
-        ]
+    network {
+        network_uuid = shakenfist_network.internal.id
+    }
 }
 
 resource "shakenfist_network" "internal" {

--- a/provider/resource_float_test.go
+++ b/provider/resource_float_test.go
@@ -48,9 +48,9 @@ func testAccResourceFloat(randomName string) string {
 			model = "cirrus"
 			memory = 16384
 		}
-		networks = [
-			"uuid=${shakenfist_network.external.id}",
-			]
+		network {
+			network_uuid = shakenfist_network.external.id
+		}
 		metadata = {
 			person = "old man"
 			action = "shakes fist"
@@ -68,7 +68,7 @@ func testAccResourceFloat(randomName string) string {
 	}
 
 	resource "shakenfist_float" "jump" {
-		interface = shakenfist_instance.jump.interfaces[0]
+		interface = shakenfist_instance.jump.network[0].interface_uuid
 	}`
 
 	r := strings.NewReplacer("{name}", randomName)

--- a/provider/resource_network.go
+++ b/provider/resource_network.go
@@ -17,13 +17,15 @@ func validateNetblock(v interface{}, k string) ([]string, []error) {
 
 	value, ok := v.(string)
 	if !ok {
-		errs = append(errs, fmt.Errorf("Expected name to be string"))
+		errs = append(errs, fmt.Errorf("Expected netblock to be a string"))
 		return warns, errs
 	}
 
-	netblock := regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/[0-9]+$`)
+	netblock := regexp.MustCompile(
+		`^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,3}$`)
 	if !netblock.Match([]byte(value)) {
-		errs = append(errs, fmt.Errorf("Netblock must be IPv4 CIDR. Got %s", value))
+		errs = append(errs,
+			fmt.Errorf("Netblock must be IPv4 CIDR. Got %s", value))
 		return warns, errs
 	}
 	return warns, errs


### PR DESCRIPTION
The instance block called ```networks``` has been renamed ```network```. 

It might make more sense for it to be```interface``` but that is a bit generic in the context of a VM instance. 
So it could be ```network_interface``` but that is too verbose. ```network``` seems a good compromise. 

Not offended if somebody wants to rename it ```network_interface``` or maybe ```net_interface```.

### Notes for @LudvikGalois :

I've (un)helpfully removed the 's' from the ```networks``` block name - now ```network```.

 ```
 networks = [
        "uuid=${shakenfist_network.internal.id}",
        ]
```
is now
```
network {
    network_uuid = shakenfist_network.internal.id
    mac = "12:34:56:78:9a:bc"
    model = "e1000"
    ipv4 = "10.0.2.100"
}
```
The parameters for network interface creation are optional except for network uuid.
