### PR TITLE
Set default for instance video card

### DIFF
--- a/provider/resource_instance.go
+++ b/provider/resource_instance.go
@@ -72,19 +72,21 @@ func resourceInstance() *schema.Resource {
 			},
 			"video": {
 				Type:     schema.TypeList,
-				Required: true,
+				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"memory": {
 							Type:        schema.TypeInt,
-							Required:    true,
+							Optional:    true,
 							ForceNew:    true,
+							Default:     16384,
 							Description: "The amount of video card RAM in KB",
 						},
 						"model": {
 							Type:        schema.TypeString,
-							Required:    true,
+							Optional:    true,
 							ForceNew:    true,
+							Default:     "cirrus",
 							Description: "The video card model",
 						},
 					},
@@ -196,13 +198,17 @@ func resourceCreateInstance(d *schema.ResourceData, m interface{}) error {
 	}
 
 	videoConf := d.Get("video").([]interface{})
-	if len(videoConf) != 1 {
+	if len(videoConf) > 1 {
 		return fmt.Errorf("Instances only accept one video card ")
 	}
-	v := videoConf[0].(map[string]interface{})
-	video := client.VideoSpec{
-		Model:  v["model"].(string),
-		Memory: v["memory"].(int),
+	video := client.VideoSpec{}
+	if len(videoConf) == 0 {
+		video.Model = "cirrus"
+		video.Memory = 16384
+	} else {
+		v := videoConf[0].(map[string]interface{})
+		video.Model = v["model"].(string)
+		video.Memory = v["memory"].(int)
 	}
 
 	inst, err := apiClient.CreateInstance(d.Get("name").(string),


### PR DESCRIPTION
Resolves #22 

This took some time because of Terraform behaviour I was not expecting.

It performs correctly by applying the defaults but upon re-applying it flags modifications but does NOT make changes to the server.
```
andy@arwen:/andy/Projects/5d/sf/terraform-provider-shakenfist/examples/one_instance$ terraform apply --auto-approve
shakenfist_network.sf-net-1: Refreshing state... [id=7cd67842-2878-440a-a0b7-e8dd4457274d]
shakenfist_instance.sftest: Refreshing state... [id=5bff1254-11ab-482c-b29c-f32233519296]
shakenfist_float.sf-float-1: Refreshing state... [id=b4e2f466-ac86-4ad1-af99-02849532b88c]
shakenfist_instance.sftest: Modifying... [id=5bff1254-11ab-482c-b29c-f32233519296]
shakenfist_instance.sftest: Modifications complete after 0s [id=5bff1254-11ab-482c-b29c-f32233519296]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```
I guess this behaviour does make sense. The "modification" refers to the fact that it modified the TF file by applying a default. It doesn't actually take any action.

Flagging it here, in case a TF expert thinks I have got it wrong...